### PR TITLE
ACE barrel stats, accuracy values and tweaks to ammo

### DIFF
--- a/addons/main/CfgAmmo.hpp
+++ b/addons/main/CfgAmmo.hpp
@@ -9,9 +9,12 @@ class CfgAmmo {
     class B_762x51_Ball;
     class HLC_GP11_FMJ: B_762x51_Ball {
         ACE_bulletLength = 35.0012;
+        caliber = 0.5;
     };
     class HLC_GP11_APBT: B_762x51_Ball {
         ACE_bulletLength = 35.0012;
+        caliber = 0.68; // 5 mm steel at 500 m
+        typicalSpeed = 750; // down from 910, same as others
     };
 
     class FH_545x39_Tracer;

--- a/addons/main/config.cpp
+++ b/addons/main/config.cpp
@@ -67,6 +67,9 @@ class CfgPatches {
 class Mode_SemiAuto;
 class Mode_FullAuto;
 class Mode_Burst;
+class FullAuto;
+class Single;
+class Burst;
 
 class asdg_OpticRail1913_long;
 class nia_rifle_gripod_slot;

--- a/addons/main/weapons/CfgWeapAK.hpp
+++ b/addons/main/weapons/CfgWeapAK.hpp
@@ -11,6 +11,8 @@ class hlc_ak_base: Rifle_Base_F {
 };
 
 class hlc_rifle_ak12: hlc_ak_base {
+    ACE_barrelTwist = 200;
+    ACE_barrelLength = 415;
     displayName = "AK-12";
     magazineWell[] += {"AK_545x39"};
     class WeaponSlotsInfo {
@@ -24,6 +26,7 @@ class hlc_rifle_ak12GL: hlc_rifle_ak12 {
     };
 };
 class hlc_rifle_aku12: hlc_rifle_ak12 {
+    ACE_barrelLength = 250;
     descriptionShort = "SMG<br/>Caliber:5.45x39mm";
     displayName = "AK-12K";
     class WeaponSlotsInfo: WeaponSlotsInfo {
@@ -31,12 +34,22 @@ class hlc_rifle_aku12: hlc_rifle_ak12 {
     };
 };
 class hlc_rifle_RPK12: hlc_rifle_ak12 {
+    ACE_barrelTwist = 200;
     descriptionShort = "Light Support Weapon<br/>Caliber:5.45x39mm";
     displayName = "RPK-16";
     class WeaponSlotsInfo: WeaponSlotsInfo {
         mass = 98;
         class GripodSlot: WB_rifle_grips_slot {};
         class UnderBarrelSlot: WB_rifle_grips_slot {};
+    };
+    class Single: Single {
+      dispersion = 0.00097;
+    };
+    class FullAuto: FullAuto {
+      dispersion = 0.00097;
+    };
+    class Burst: Burst {
+      dispersion = 0.00097;
     };
 };
 
@@ -205,6 +218,8 @@ class hlc_rifle_aek971worn: hlc_rifle_aek971 {
 };
 
 class hlc_rifle_RK62: hlc_ak_base {
+    ACE_barrelTwist = 199.898;
+    ACE_barrelLength = 418;
     displayName = "RK 62";
     magazines[] = {"hlc_30Rnd_762x39_b_ak_Valmet"};
     magazineWell[] += {"AK_762x39"};
@@ -227,8 +242,15 @@ class hlc_rifle_rpk: hlc_ak_base {
     class WeaponSlotsInfo: WeaponSlotsInfo {
         mass = 107;
     };
+    class Single: Single {
+      dispersion = 0.0011;
+    };
+    class FullAuto: FullAuto {
+      dispersion = 0.0011;
+    };
 };
 class hlc_rifle_rpk74n: hlc_ak_base {
+    ACE_barrelTwist = 200;
     descriptionShort = "Light Support Weapon<br/>Caliber:5.45x39mm";
     displayName = "RPK-74N";
     magazineWell[] += {"AK_545x39"};
@@ -241,6 +263,12 @@ class hlc_rifle_rpk74n: hlc_ak_base {
     rhs_pso1m21_type = "rhs_acc_pso1m21_svd";
     class WeaponSlotsInfo: WeaponSlotsInfo {
         mass = 101;
+    };
+    class Single: Single {
+      dispersion = 0.0011;
+    };
+    class FullAuto: FullAuto {
+      dispersion = 0.0011;
     };
 };
 

--- a/addons/main/weapons/CfgWeapAR15.hpp
+++ b/addons/main/weapons/CfgWeapAR15.hpp
@@ -147,8 +147,6 @@ class hlc_wp_xm4: hlc_M16Base {
     };
 };
 class hlc_wp_XM177E2: hlc_M16Base {
-    ACE_barrelTwist = 304.8;
-    ACE_barrelLength = 292;
     class WeaponSlotsInfo: WeaponSlotsInfo {
         mass = 65;
     };

--- a/addons/main/weapons/CfgWeapAR15.hpp
+++ b/addons/main/weapons/CfgWeapAR15.hpp
@@ -76,6 +76,7 @@ class hlc_rifle_CQBR: hlc_rifle_RU556 {
     };
 };
 class hlc_rifle_mk18mod0: hlc_rifle_CQBR {
+    ACE_barrelLength = 262;
     class WeaponSlotsInfo: WeaponSlotsInfo {
         mass = 60;
     };
@@ -85,10 +86,22 @@ class hlc_rifle_Colt727: hlc_ar15_base {
     class WeaponSlotsInfo: WeaponSlotsInfo {
         mass = 69.5;
     };
+    class Single: Single {
+      dispersion = 0.00093;
+    };
+    class FullAuto: FullAuto {
+      dispersion = 0.00093;
+    };
 };
 class hlc_rifle_Colt727_GL: hlc_rifle_Colt727 {
     class WeaponSlotsInfo: WeaponSlotsInfo {
         mass = 102.5;
+    };
+    class Single: Single {
+      dispersion = 0.00093;
+    };
+    class FullAuto: FullAuto {
+      dispersion = 0.00093;
     };
 };
 
@@ -122,6 +135,8 @@ class hlc_wp_mod727: hlc_M16Base {
     };
 };
 class hlc_wp_mod733: hlc_M16Base {
+    ACE_barrelTwist = 228.6;
+    ACE_barrelLength = 292;
     class WeaponSlotsInfo: WeaponSlotsInfo {
         mass = 63.8;
     };
@@ -132,7 +147,15 @@ class hlc_wp_xm4: hlc_M16Base {
     };
 };
 class hlc_wp_XM177E2: hlc_M16Base {
+    ACE_barrelTwist = 304.8;
+    ACE_barrelLength = 292;
     class WeaponSlotsInfo: WeaponSlotsInfo {
         mass = 65;
+    };
+    class FullAuto: Burst {
+      dispersion =  0.0022;
+    };
+    class Single: Mode_SemiAuto {
+      dispersion =  0.0022;
     };
 };

--- a/addons/main/weapons/CfgWeapAWM.hpp
+++ b/addons/main/weapons/CfgWeapAWM.hpp
@@ -1,6 +1,5 @@
 class hlc_AWC_base: Rifle_Base_F {
     ACE_barrelLength = 686;
-    ACE_barrelTwist = 279.4;
     class WeaponSlotsInfo: WeaponSlotsInfo {
         class CowsSlot: asdg_OpticRail1913_long {};
     };

--- a/addons/main/weapons/CfgWeapAWM.hpp
+++ b/addons/main/weapons/CfgWeapAWM.hpp
@@ -1,4 +1,6 @@
 class hlc_AWC_base: Rifle_Base_F {
+    ACE_barrelLength = 686;
+    ACE_barrelTwist = 279.4;
     class WeaponSlotsInfo: WeaponSlotsInfo {
         class CowsSlot: asdg_OpticRail1913_long {};
     };

--- a/addons/main/weapons/CfgWeapFAL.hpp
+++ b/addons/main/weapons/CfgWeapFAL.hpp
@@ -31,6 +31,8 @@ class hlc_rifle_C2A1: hlc_fal_base {
 };
 
 class hlc_rifle_FAL5061: hlc_fal_base {
+    ACE_barrelTwist = 304.8;
+    ACE_barrelLength = 458;
     displayName = "FN FAL 50.62";
     class WeaponSlotsInfo: WeaponSlotsInfo {
         mass = 95;
@@ -45,24 +47,32 @@ class hlc_rifle_LAR: hlc_rifle_FAL5061 {
     };
 };
 class hlc_rifle_FAL5000: hlc_rifle_FAL5061 {
+    ACE_barrelTwist = 304.8;
+    ACE_barrelLength = 533;
     class WeaponSlotsInfo: WeaponSlotsInfo {
         mass = 94;
         class CowsSlot: asdg_OpticRailL1A1 {};
     };
 };
 class hlc_rifle_FAL5000_RH: hlc_rifle_FAL5000 {
+    ACE_barrelTwist = 304.8;
+    ACE_barrelLength = 533;
     class WeaponSlotsInfo: WeaponSlotsInfo {
         mass = 94;
         class CowsSlot: asdg_OpticRailL1A1 {};
     };
 };
 class hlc_rifle_FAL5061Rail: hlc_fal_base {
+    ACE_barrelTwist = 304.8;
+    ACE_barrelLength = 458;
     displayName = "FN FAL 50.62 (RIS)";
     class WeaponSlotsInfo: WeaponSlotsInfo {
         mass = 97;
     };
 };
 class hlc_rifle_FAL5000Rail: hlc_rifle_FAL5061Rail {
+    ACE_barrelTwist = 304.8;
+    ACE_barrelLength = 533;
     class WeaponSlotsInfo: WeaponSlotsInfo {
         mass = 96;
     };

--- a/addons/main/weapons/CfgWeapG36.hpp
+++ b/addons/main/weapons/CfgWeapG36.hpp
@@ -41,6 +41,7 @@ class hlc_rifle_G36KE1: hlc_rifle_G36KA1 {
     };
 };
 class hlc_rifle_G36C: hlc_G36_base {
+    ACE_barrelLength = 228;
     displayName = "HK G36C";
     class WeaponSlotsInfo: WeaponSlotsInfo {
         mass = 65.7;
@@ -53,12 +54,14 @@ class hlc_rifle_G36V: hlc_G36_base {
     };
 };
 class hlc_rifle_G36CV: hlc_rifle_G36V {
+    ACE_barrelLength = 228;
     displayName = "HK G36CV";
     class WeaponSlotsInfo: WeaponSlotsInfo {
         mass = 65.7;
     };
 };
 class hlc_rifle_G36CTac: hlc_rifle_G36CV {
+    ACE_barrelLength = 228;
     displayName = "HK G36CV (TAC)";
     class WeaponSlotsInfo: WeaponSlotsInfo {
         mass = 67.7;
@@ -103,6 +106,7 @@ class hlc_rifle_g36KTac: hlc_rifle_G36KV {
     };
 };
 class hlc_rifle_G36MLIC: hlc_G36_base {
+    ACE_barrelLength = 228;
     displayName = "HK G36-MLI(C)";
     class WeaponSlotsInfo: WeaponSlotsInfo {
         mass = 84.2;

--- a/addons/main/weapons/CfgWeapMG.hpp
+++ b/addons/main/weapons/CfgWeapMG.hpp
@@ -12,15 +12,22 @@ class HLC_wp_M134Painless: Rifle_Base_F {
 
 class hlc_M60e4_base: Rifle_Base_F {
     class WeaponSlotsInfo;
+    ace_overheating_closedBolt = 0;
 };
 class hlc_lmg_m60: hlc_M60e4_base {
     delete nia_magSwitch;
     class WeaponSlotsInfo: WeaponSlotsInfo {
         mass = 231;
     };
+    class FullAuto: FullAuto {
+      dispersion = 0.00095;
+    };
 };
 class hlc_lmg_M60E4: hlc_M60e4_base {
     delete nia_magSwitch;
+    class FullAuto: FullAuto {
+      dispersion = 0.001;
+    };
 };
 
 class hlc_MG42_base: Rifle_Base_F {

--- a/addons/main/weapons/CfgWeapMP5.hpp
+++ b/addons/main/weapons/CfgWeapMP5.hpp
@@ -53,24 +53,28 @@ class hlc_smg_mp5N_tac: hlc_smg_MP5N {
     };
 };
 class hlc_smg_mp5k_PDW: hlc_MP5_base {
+    ACE_barrelLength = 148;
     displayName = "HK MP5K-PDW";
     class WeaponSlotsInfo: WeaponSlotsInfo {
         mass = 56;
     };
 };
 class hlc_smg_mp5k: hlc_smg_mp5k_PDW {
+    ACE_barrelLength = 115;
     displayName = "HK MP5K";
     class WeaponSlotsInfo: WeaponSlotsInfo {
         mass = 44;
     };
 };
 class hlc_smg_mp5sd5: hlc_MP5_base {
+    ACE_barrelLength = 146;
     displayName = "HK MP5SD5";
     class WeaponSlotsInfo: WeaponSlotsInfo {
         mass = 70.5;
     };
 };
 class hlc_smg_mp5sd6: hlc_smg_mp5sd5 {
+    ACE_barrelLength = 146;
     displayName = "HK MP5SD6";
     class WeaponSlotsInfo: WeaponSlotsInfo {
         mass = 75;

--- a/addons/main/weapons/CfgWeapMisc.hpp
+++ b/addons/main/weapons/CfgWeapMisc.hpp
@@ -4,6 +4,7 @@ class hlc_STGW_base: Rifle_Base_F {
     class WeaponSlotsInfo;
 };
 class hlc_rifle_STGW57: hlc_STGW_base {
+    ACE_barrelLength = 609;
     class WeaponSlotsInfo: WeaponSlotsInfo {
         mass = 125.6;
         class CowsSlot: UK3CB_OpticRail1913_STGW57 {};

--- a/addons/main/weapons/CfgWeapSAW.hpp
+++ b/addons/main/weapons/CfgWeapSAW.hpp
@@ -1,5 +1,6 @@
 class hlc_saw_base: Rifle_Base_F {
     class WeaponSlotsInfo;
+    ace_overheating_closedBolt = 0;
 };
 class hlc_lmg_minimipara: hlc_saw_base {
     magazineWell[] += {"CBA_556x45_STANAG_2D","CBA_556x45_STANAG_2D_XL"};
@@ -117,6 +118,10 @@ class hlc_m249_SQuantoon_grip3: hlc_m249_SQuantoon {
 };
 
 class hlc_lmg_mk46: hlc_lmg_minimi_railed {
+    ACE_barrelTwist = 177.8;
+    class FullAuto: FullAuto {
+      dispersion = 0.0009;
+    };
     class WeaponSlotsInfo {
         mass = 154.4;
         class CowsSlot: asdg_OpticRail1913_long {};
@@ -125,6 +130,10 @@ class hlc_lmg_mk46: hlc_lmg_minimi_railed {
     };
 };
 class hlc_lmg_mk46mod1: hlc_lmg_mk46 {
+    ACE_barrelTwist = 177.8;
+    class FullAuto: FullAuto {
+      dispersion = 0.0009;
+    };
     class WeaponSlotsInfo: WeaponSlotsInfo {
         mass = 152.4;
         class CowsSlot: asdg_OpticRail1913 {};
@@ -134,16 +143,26 @@ class hlc_lmg_mk46mod1: hlc_lmg_mk46 {
 };
 
 class hlc_lmg_mk48: hlc_saw_base {
+    ACE_barrelLength = 502;
     class WeaponSlotsInfo {
         mass = 182.6;
         class CowsSlot: asdg_OpticRail1913_long {};
     };
+    class FullAuto: FullAuto
+    {
+      dispersion = 0.0009;
+    };
 };
 class hlc_lmg_mk48mod1: hlc_lmg_mk48 {
+    ACE_barrelLength = 502;
     class WeaponSlotsInfo: WeaponSlotsInfo {
         mass = 186.6;
         class CowsSlot: asdg_OpticRail1913 {};
         class GripodSlot: nia_rifle_gripod_slot {};
         class UnderBarrelSlot: WB_rifle_grips_slot {};
+    };
+    class FullAuto: FullAuto
+    {
+      dispersion = 0.0009;
     };
 };

--- a/addons/main/weapons/CfgWeapSG550.hpp
+++ b/addons/main/weapons/CfgWeapSG550.hpp
@@ -1,7 +1,9 @@
 class hlc_sg550_base: Rifle_Base_F {
+    ACE_barrelTwist = 254;
     class WeaponSlotsInfo;
 };
 class hlc_rifle_SG550: hlc_sg550_base {
+    ACE_barrelTwist = 254;
     class WeaponSlotsInfo: WeaponSlotsInfo {
         mass = 90;
     };


### PR DESCRIPTION
- Fixes to ACE3 barrel stats for guns that were missing them completely or had incorrect ones
- Nerfs the accuracy of some weapons. For example some of the machine guns are like sniper rifles by default.
- A few small tweaks to CfgAmmo
- ACE3 open bolt configuration for some of the machine guns